### PR TITLE
Move validator error message to plone domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,22 @@ Usage
 See the `demo <https://github.com/plone/plone.formwidget.hcaptcha/tree/master/src/plone/formwidget/hcaptcha/demo>`_ folder inside the distribution for an example usage.
 
 Supermodel
-^^^^^^^^^^
+----------
 You can add a captcha field in an XML model by adding something like this::
 
     <field name="captcha" type="plone.formwidget.hcaptcha.HCaptchaWidget">
       <title>Solve Captcha</title>
       <description></description>
     </field>
+
+Translations
+------------
+
+The only day to day visible message will be the error message when a hcaptcha validation fails. The message string is located in validator.py and has been put in the 'plone' domain.
+Translations will be added to plone.app.locales. 
+
+If you want to add/override your own translation for this, for buildout you can use the locales attribute of plone.recipe.zope2instance to register a locales directory in your project where you can add a plone.po file. Alternatively you can add the same plone.po file
+in a policy package, but you have to make sure the zcml of that package is called first.
 
 
 

--- a/news/6.bugfix
+++ b/news/6.bugfix
@@ -1,0 +1,1 @@
+Move validator error message to plone translation domain so it can be added to plone.app.locales. [fredvd]

--- a/src/plone/formwidget/hcaptcha/validator.py
+++ b/src/plone/formwidget/hcaptcha/validator.py
@@ -4,13 +4,10 @@ from z3c.form import validator
 from zope.component import getMultiAdapter
 from zope.i18nmessageid import MessageFactory
 from zope.schema import ValidationError
-
-
-_ = MessageFactory("plone.formwidget.hcaptcha")
-
+from Products.CMFPlone import PloneMessageFactory as _
 
 class WrongCaptchaCode(ValidationError):
-    __doc__ = _(u"The code you entered was wrong, please enter the new one.")
+    __doc__ = _(u"The verification you entered was wrong, please try a new one.")
 
 
 class HCaptchaValidator(validator.SimpleFieldValidator):


### PR DESCRIPTION
 so it can be added to plone.app.locales and/or easier overriden.