### PR TITLE
Fix hCaptcha verification to use the documented endpoint 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,21 @@ documentation at https://docs.hcaptcha.com/.
 To actually use the service, you must obtain a site key and secret key from
 `https://www.hcaptcha.com/signup-interstitial <https://www.hcaptcha.com/signup-interstitial/>`_
 
+Verification endpoint
+---------------------
+According to the official hCaptcha documentation (https://docs.hcaptcha.com/#server),
+the token verification endpoint is:
+
+``https://api.hcaptcha.com/siteverify``
+
+This package now uses ``api.hcaptcha.com`` by default instead of ``hcaptcha.com``.
+If you need to change the host (e.g. staging or internal testing), set the environment
+variable before starting your Plone instance:
+
+``HCAPTCHA_VERIFY_SERVER=api.hcaptcha.com``
+
+If the variable is not defined, the safe default (``api.hcaptcha.com``) will be used.
+
 Usage
 -----
 See the `demo <https://github.com/plone/plone.formwidget.hcaptcha/tree/master/src/plone/formwidget/hcaptcha/demo>`_ folder inside the distribution for an example usage.

--- a/news/13.bugfix
+++ b/news/13.bugfix
@@ -1,0 +1,1 @@
+Fix hCaptcha verification to use the documented endpoint (api.hcaptcha.com/siteverify) and allow overriding the host via the HCAPTCHA_VERIFY_SERVER environment variable. @alexandreIFB

--- a/src/plone/formwidget/hcaptcha/nohcaptcha.py
+++ b/src/plone/formwidget/hcaptcha/nohcaptcha.py
@@ -5,6 +5,7 @@
 from six.moves.urllib import parse
 from six.moves.urllib.request import Request
 from six.moves.urllib.request import urlopen
+import os
 
 import six
 
@@ -14,9 +15,7 @@ try:
 except ImportError:
     import simplejson as json
 
-
-VERIFY_SERVER = "hcaptcha.com"
-
+VERIFY_SERVER = os.getenv("HCAPTCHA_VERIFY_SERVER", "api.hcaptcha.com")
 
 class HcaptchaResponse(object):
     def __init__(self, is_valid, error_code=None):


### PR DESCRIPTION
Body:
This PR fixes the hCaptcha verification request to use the documented endpoint:


https://api.hcaptcha.com/siteverify
Changes:

Update nohcaptcha.py to default VERIFY_SERVER to api.hcaptcha.com
Allow overriding via HCAPTCHA_VERIFY_SERVER environment variable
Add README section documenting the endpoint and env var
Add news entry (13.bugfix)
Why:
hcaptcha.com/siteverify is not the canonical host per official docs; using api.hcaptcha.com avoids relying on redirects and matches the specification.

How to test:

Submit a form using the hCaptcha widget; verify POST goes to api.hcaptcha.com/siteverify.
Optional: export HCAPTCHA_VERIFY_SERVER=example.invalid and restart; request should target the custom host.
Unset var to confirm fallback works.
No breaking changes; low risk.